### PR TITLE
Retrieve product concrete storage data by id instead of using missing key from mapping resource

### DIFF
--- a/src/Spryker/Client/ProductResourceAliasStorage/Storage/ProductConcreteStorageBySkuReader.php
+++ b/src/Spryker/Client/ProductResourceAliasStorage/Storage/ProductConcreteStorageBySkuReader.php
@@ -82,7 +82,7 @@ class ProductConcreteStorageBySkuReader implements ProductConcreteStorageReaderI
     {
         $synchronizationDataTransfer = new SynchronizationDataTransfer();
         $synchronizationDataTransfer
-            ->setReference($productConcreteId)
+            ->setReference((string)$productConcreteId)
             ->setLocale($localeName);
 
         return $this->synchronizationService

--- a/src/Spryker/Client/ProductResourceAliasStorage/Storage/ProductConcreteStorageBySkuReader.php
+++ b/src/Spryker/Client/ProductResourceAliasStorage/Storage/ProductConcreteStorageBySkuReader.php
@@ -62,6 +62,31 @@ class ProductConcreteStorageBySkuReader implements ProductConcreteStorageReaderI
             return null;
         }
 
-        return $this->storageClient->get($mappingResource['key']);
+        $productConcreteId = $mappingResource['id'] ?? null;
+        if (!$productConcreteId) {
+            return null;
+        }
+
+        $key = $this->getProductConcreteStorageResourceKey($productConcreteId, $localeName);
+
+        return $this->storageClient->get($key);
+    }
+
+    /**
+     * @param int $productConcreteId
+     * @param string $localeName
+     *
+     * @return string
+     */
+    protected function getProductConcreteStorageResourceKey(int $productConcreteId, string $localeName): string
+    {
+        $synchronizationDataTransfer = new SynchronizationDataTransfer();
+        $synchronizationDataTransfer
+            ->setReference($productConcreteId)
+            ->setLocale($localeName);
+
+        return $this->synchronizationService
+            ->getStorageKeyBuilder(ProductStorageConstants::PRODUCT_CONCRETE_RESOURCE_NAME)
+            ->generateKey($synchronizationDataTransfer);
     }
 }


### PR DESCRIPTION
## PR Description

Product resource alias storage data doesn't contain resource key, only product id:
![image](https://github.com/user-attachments/assets/29bbcf82-c662-4e5a-abbf-b05d4bf99200)

The code expects that the resource key is provided in storage, which is not true according to the latest storage data.
Instead of relying on resource key provided in storage, I added a code fragment to generate resource key from product concrete ID provided in storage data.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
